### PR TITLE
Added Indent code functionality with Tab key and Unit tested the Tab key

### DIFF
--- a/client/src/components/Editor.vue
+++ b/client/src/components/Editor.vue
@@ -6,17 +6,22 @@
 
 <script>
 const getKeyValueToRender = (keyCode, keyValue) => {
-  // Enter
-  if (keyCode === 13) {
-    return '\n';
+  switch (keyCode) {
+    // Enter
+    case 13:
+      return '\n';
+    // Tab
+    case 9:
+      return '\xa0\xa0';
+    default:
+      return keyValue;
   }
-  return keyValue;
 };
 
 export default {
   name: 'Editor',
   data: () => ({
-    documentData: ''
+    documentData: '',
   }),
   // define methods under the `methods` object
   methods: {
@@ -25,15 +30,13 @@ export default {
       // backspace
       if (event.keyCode === 8) {
         this.documentData = this.documentData.slice(0, -1);
-      }
-
-      // handle key input
-      else {
+      } else {
+        // handle key input
         this.documentData =
           this.documentData + getKeyValueToRender(event.keyCode, event.key);
       }
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/client/test/unit/specs/Editor.spec.js
+++ b/client/test/unit/specs/Editor.spec.js
@@ -45,6 +45,10 @@ describe('Editor.vue', () => {
     backspace: {
       keyCode: 8,
     },
+    tab: {
+      keyCode: 9,
+      key: 'tab',
+    },
   };
 
   test('Adds the "a" character to the editor when it is pressed', () => {
@@ -93,6 +97,21 @@ describe('Editor.vue', () => {
     wrapper.trigger('keydown.enter');
     wrapper.trigger('keydown', keyCodes.backspace);
     expect(wrapper.find('div[data-test="editor"]').text()).toBe('abc');
+  });
+
+  test('The tab key indents with 2 spaces', () => {
+    const wrapper = mount(Component);
+    wrapper.trigger('keydown', keyCodes.a);
+    wrapper.trigger('keydown', keyCodes.b);
+    wrapper.trigger('keydown', keyCodes.c);
+    wrapper.trigger('keydown.enter');
+    wrapper.trigger('keydown', keyCodes.tab);
+    wrapper.trigger('keydown', keyCodes[1]);
+    wrapper.trigger('keydown', keyCodes[2]);
+    wrapper.trigger('keydown', keyCodes[3]);
+    expect(wrapper.find('div[data-test="editor"]').text()).toBe(
+      'abc\n\xa0\xa0123',
+    );
   });
 });
 

--- a/client/test/unit/specs/Editor.spec.js
+++ b/client/test/unit/specs/Editor.spec.js
@@ -17,6 +17,8 @@ describe('Editor.vue', () => {
     expect(wrapper.find('div[data-test="editor"]').text()).toBe('');
   });
 
+  const space = '\xa0';
+  const tab = space + space;
   const keyCodes = {
     a: {
       keyCode: 65,
@@ -99,19 +101,22 @@ describe('Editor.vue', () => {
     expect(wrapper.find('div[data-test="editor"]').text()).toBe('abc');
   });
 
-  test('The tab key indents with 2 spaces', () => {
+  test('The tab key gets added to the Vue document object', () => {
+    const wrapper = mount(Component);
+    wrapper.trigger('keydown', keyCodes.tab);
+    expect(wrapper.vm.documentData).toBe(tab);
+  });
+
+  test('The tab key gets added to the document', () => {
+    /*
+      Note that .text() trims the resulting string as seen here: https://github.com/vuejs/vue-test-utils/issues/152
+      Therefore we have wrapped the tab in two characters
+    */
     const wrapper = mount(Component);
     wrapper.trigger('keydown', keyCodes.a);
-    wrapper.trigger('keydown', keyCodes.b);
-    wrapper.trigger('keydown', keyCodes.c);
-    wrapper.trigger('keydown.enter');
     wrapper.trigger('keydown', keyCodes.tab);
-    wrapper.trigger('keydown', keyCodes[1]);
-    wrapper.trigger('keydown', keyCodes[2]);
-    wrapper.trigger('keydown', keyCodes[3]);
-    expect(wrapper.find('div[data-test="editor"]').text()).toBe(
-      'abc\n\xa0\xa0123',
-    );
+    wrapper.trigger('keydown', keyCodes.a);
+    expect(wrapper.find('div[data-test="editor"]').text()).toBe(`a${tab}a`);
   });
 });
 


### PR DESCRIPTION
- Added two spaces "\xa0\xa0" when Indenting the code on Tab key
- Resolve issue #15 