### PR TITLE
saving documentData to localStorage

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,23 +7,19 @@
   "scripts": {
     "precommit": "lint-staged",
     "prepush": "yarn unit",
-    "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
+    "dev":
+      "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "yarn dev",
-    "unit": "jest --config test/unit/jest.conf.js --coverage",
+    "unit": "jest --config test/unit/jest.conf.js",
+    "unit:coverage": "jest --config test/unit/jest.conf.js --coverage",
     "e2e": "node test/e2e/runner.js",
     "test": "yarn unit && yarn e2e",
     "lint": "eslint --ext .js,.vue src test/unit test/e2e/specs",
     "build": "node build/build.js"
   },
   "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ],
-    "*.vue": [
-      "eslint --fix",
-      "git add"
-    ]
+    "*.js": ["eslint --fix", "git add"],
+    "*.vue": ["eslint --fix", "git add"]
   },
   "dependencies": {
     "vue": "^2.5.2",
@@ -95,9 +91,5 @@
     "node": ">= 6.0.0",
     "npm": ">= 3.0.0"
   },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+  "browserslist": ["> 1%", "last 2 versions", "not ie <= 8"]
 }

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
       "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "yarn dev",
     "unit": "jest --config test/unit/jest.conf.js",
-    "unit:coverage": "jest --config test/unit/jest.conf.js --coverage",
+    "unit:coverage": "yarn unit --coverage",
     "e2e": "node test/e2e/runner.js",
     "test": "yarn unit && yarn e2e",
     "lint": "eslint --ext .js,.vue src test/unit test/e2e/specs",

--- a/client/src/components/Home/components/Editor.vue
+++ b/client/src/components/Home/components/Editor.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="editor" @keydown.prevent="handleKeyboardPress" tabindex="0" data-test="editor">
-    {{ documentData }}
-  </div>
+  <div
+    class="editor"
+    @keydown.prevent="handleKeyboardPress"
+    tabindex="0"
+    data-test="editor"
+  >{{documentData}}</div>
 </template>
 
 <script>

--- a/client/src/components/Home/components/Editor.vue
+++ b/client/src/components/Home/components/Editor.vue
@@ -26,6 +26,11 @@ export default {
   data: () => ({
     documentData: '',
   }),
+  mounted() {
+    if (localStorage && localStorage.documentData) {
+      this.documentData = localStorage.documentData;
+    }
+  },
   // define methods under the `methods` object
   methods: {
     handleKeyboardPress(event) {
@@ -38,6 +43,7 @@ export default {
         this.documentData =
           this.documentData + getKeyValueToRender(event.keyCode, event.key);
       }
+      localStorage.setItem('documentData', this.documentData);
     },
   },
 };

--- a/client/src/components/Home/components/Editor.vue
+++ b/client/src/components/Home/components/Editor.vue
@@ -21,16 +21,24 @@ const getKeyValueToRender = (keyCode, keyValue) => {
   }
 };
 
+const getDefaultValue = () => {
+  if (window && window.localStorage) {
+    return window.localStorage.getItem('documentData') || '';
+  }
+  return '';
+};
+
+const setValueToStorage = (value) => {
+  if (window && window.localStorage) {
+    window.localStorage.setItem('documentData', value);
+  }
+};
+
 export default {
   name: 'Editor',
   data: () => ({
-    documentData: '',
+    documentData: getDefaultValue(),
   }),
-  mounted() {
-    if (localStorage && localStorage.documentData) {
-      this.documentData = localStorage.documentData;
-    }
-  },
   // define methods under the `methods` object
   methods: {
     handleKeyboardPress(event) {
@@ -43,7 +51,7 @@ export default {
         this.documentData =
           this.documentData + getKeyValueToRender(event.keyCode, event.key);
       }
-      localStorage.setItem('documentData', this.documentData);
+      setValueToStorage(this.documentData);
     },
   },
 };

--- a/client/test/unit/setup.js
+++ b/client/test/unit/setup.js
@@ -1,3 +1,23 @@
 import Vue from 'vue';
 
 Vue.config.productionTip = false;
+
+const mock = (() => {
+  let store = {};
+  return {
+    getItem(key) {
+      return store[key];
+    },
+    setItem(key, value) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: mock,
+  configurable: true,
+});

--- a/client/test/unit/specs/Editor.spec.js
+++ b/client/test/unit/specs/Editor.spec.js
@@ -1,6 +1,10 @@
 import { mount } from '@vue/test-utils';
 import Component from '@/components/Home/components/Editor';
 
+afterEach(() => {
+  window.localStorage.clear();
+});
+
 describe('Editor.vue', () => {
   test('is a Vue instance', () => {
     const wrapper = mount(Component);
@@ -109,15 +113,23 @@ describe('Editor.vue', () => {
 
   test('The tab key gets added to the document', () => {
     /*
-      Note that .text() trims the resulting string as seen here: https://github.com/vuejs/vue-test-utils/issues/152
-      Therefore we have wrapped the tab in two characters
-    */
+        Note that .text() trims the resulting string as seen here: https://github.com/vuejs/vue-test-utils/issues/152
+        Therefore we have wrapped the tab in two characters
+      */
     const wrapper = mount(Component);
     wrapper.trigger('keydown', keyCodes.a);
     wrapper.trigger('keydown', keyCodes.tab);
     wrapper.trigger('keydown', keyCodes.a);
     expect(wrapper.find('div[data-test="editor"]').text()).toBe(`a${tab}a`);
   });
-});
 
-// vm.$el.querySelector('div[data-test="editor"]').textContent,
+  test('Document is saved to localstorage', () => {
+    const wrapper = mount(Component);
+    wrapper.trigger('keydown', keyCodes.a);
+
+    // Mound a second component and check that the default value is the expected
+    // value from the previous wrapper
+    const secondWrapper = mount(Component);
+    expect(secondWrapper.find('div[data-test="editor"]').text()).toBe('a');
+  });
+});


### PR DESCRIPTION
Also a couple of little things

- reformatted the div in Editor with the {{ documentData }} in it because it was creating a space at the beginning of an empty editor
- split out the unit testing script to "unit" and "unit:coverage" to make it easier to rerun the unit tests without having to wait for coverage each time