### PR TITLE
Fix issue #49 with the backspace key

### DIFF
--- a/client/src/components/Home/components/utilities.js
+++ b/client/src/components/Home/components/utilities.js
@@ -30,8 +30,11 @@ export const updateDocumentData = (
         // i.e. the document is empty. Don't remove anything else
         return newDocument;
       }
-      if (newDocument[rowIndex] === '') {
-        // If we are at the start of a new line, remove the line
+      if (offset === 0) {
+        // If we are at the start of a line, concatenate it with the
+        // previous line
+        newDocument[rowIndex - 1] =
+          newDocument[rowIndex - 1] + newDocument[rowIndex];
         newDocument.splice(rowIndex, 1);
         return newDocument;
       }
@@ -68,8 +71,9 @@ export const updateCaret = (document, { offset, rowIndex }, { keyCode }) => {
         // i.e. the document is empty. Don't remove anything else
         return { offset: 0, rowIndex: 0 };
       }
-      if (document[rowIndex] === '') {
-        // If we are at the start of a new line, remove the line
+      if (offset === 0) {
+        // If we are at the start of a line, move the caret to the end
+        // of the previous line
         return {
           offset: document[rowIndex - 1].length,
           rowIndex: rowIndex - 1,

--- a/client/src/components/Home/components/utilities.js
+++ b/client/src/components/Home/components/utilities.js
@@ -25,12 +25,12 @@ export const updateDocumentData = (
     }
     // backspace
     case 8:
-      if (newDocument.length === 1 && newDocument[0] === '') {
+      if (offset === 0 && rowIndex === 0) {
         // If we are at the very start of the document
         // i.e. the document is empty. Don't remove anything else
         return newDocument;
       }
-      if (offset === 0) {
+      if (offset === 0 && rowIndex > 0) {
         // If we are at the start of a line, concatenate it with the
         // previous line
         newDocument[rowIndex - 1] =
@@ -71,7 +71,7 @@ export const updateCaret = (document, { offset, rowIndex }, { keyCode }) => {
         // i.e. the document is empty. Don't remove anything else
         return { offset: 0, rowIndex: 0 };
       }
-      if (offset === 0) {
+      if (offset === 0 && rowIndex > 0) {
         // If we are at the start of a line, move the caret to the end
         // of the previous line
         return {


### PR DESCRIPTION
Fix the behavior of the backspace key, wherein when the caret is at
the beginning of an existing line, nothing is done. When pressed with
the caret at the beginning of a line, the backspace key should now
combine the current line and previous line at the previous row.

Close issue #49.