### PR TITLE
Add ability to move caret by arrow keys

### DIFF
--- a/client/src/components/Home/components/Editor.vue
+++ b/client/src/components/Home/components/Editor.vue
@@ -23,7 +23,8 @@ import {
   getDefaultValue,
   listOfSpecialKeys,
   setValueToStorage,
-  updateCaret,
+  updateCaretAtInput,
+  updateCaretAtSpecialKey,
   updateDocumentData,
 } from './utilities';
 
@@ -43,7 +44,9 @@ export default {
   // define methods under the `methods` object
   methods: {
     handleKeyDown(event) {
+      const documentData = this.documentData;
       if (listOfSpecialKeys[event.keyCode]) {
+        this.caret = updateCaretAtSpecialKey(documentData, this.caret, event);
         return;
       }
       // cancel if the control, alt, or meta key is held
@@ -51,9 +54,8 @@ export default {
       if (event.ctrlKey || event.altKey || event.metaKey) {
         return;
       }
-      const documentData = this.documentData;
       this.documentData = updateDocumentData(documentData, this.caret, event);
-      this.caret = updateCaret(documentData, this.caret, event);
+      this.caret = updateCaretAtInput(documentData, this.caret, event);
       setValueToStorage(this.documentData);
     },
     handleClick(event, index) {

--- a/client/src/components/Home/components/Editor.vue
+++ b/client/src/components/Home/components/Editor.vue
@@ -21,10 +21,10 @@
 <script>
 import {
   getDefaultValue,
+  caretMovementKeys,
   listOfSpecialKeys,
   setValueToStorage,
-  updateCaretAtInput,
-  updateCaretAtSpecialKey,
+  updateCaret,
   updateDocumentData,
 } from './utilities';
 
@@ -46,7 +46,6 @@ export default {
     handleKeyDown(event) {
       const documentData = this.documentData;
       if (listOfSpecialKeys[event.keyCode]) {
-        this.caret = updateCaretAtSpecialKey(documentData, this.caret, event);
         return;
       }
       // cancel if the control, alt, or meta key is held
@@ -54,9 +53,13 @@ export default {
       if (event.ctrlKey || event.altKey || event.metaKey) {
         return;
       }
-      this.documentData = updateDocumentData(documentData, this.caret, event);
-      this.caret = updateCaretAtInput(documentData, this.caret, event);
-      setValueToStorage(this.documentData);
+      // Do not update the document if the key pressed is simply meant
+      // to move the caret.
+      if (!caretMovementKeys[event.keyCode]) {
+        this.documentData = updateDocumentData(documentData, this.caret, event);
+        setValueToStorage(this.documentData);
+      }
+      this.caret = updateCaret(documentData, this.caret, event);
     },
     handleClick(event, index) {
       this.caret.offset = window.getSelection().anchorOffset;

--- a/client/src/components/Home/components/utilities.js
+++ b/client/src/components/Home/components/utilities.js
@@ -56,12 +56,16 @@ export const updateDocumentData = (
   }
 };
 
-export const updateCaret = (document, { offset, rowIndex }, { keyCode }) => {
+export const updateCaretAtInput = (
+  document,
+  { offset, rowIndex },
+  { keyCode },
+) => {
   switch (keyCode) {
     // Enter
     case 13:
       return { offset: 0, rowIndex: rowIndex + 1 };
-    // backspace
+    // Backspace
     case 8:
       if (offset === 0 && rowIndex === 0) {
         // If we are at the very start of the document
@@ -82,6 +86,70 @@ export const updateCaret = (document, { offset, rowIndex }, { keyCode }) => {
       return { offset: offset + 2, rowIndex };
     default:
       return { offset: offset + 1, rowIndex };
+  }
+};
+
+export const updateCaretAtSpecialKey = (
+  document,
+  { offset, rowIndex },
+  { keyCode },
+) => {
+  switch (keyCode) {
+    // Left arrow key
+    case 37:
+      // If the caret is at the beginning of the document, keep it as it is
+      if (offset === 0 && rowIndex === 0) {
+        return { offset: 0, rowIndex: 0 };
+      } else if (offset === 0) {
+        // If the caret is at the beginning of the current line, move the caret to
+        // the end of the previous line
+        return {
+          offset: document[rowIndex - 1].length,
+          rowIndex: rowIndex - 1,
+        };
+      }
+      return { offset: offset - 1, rowIndex };
+    // Up arrow key
+    case 38:
+      // If the caret is at the top of the document, keep it as it is
+      if (rowIndex === 0) {
+        return { offset: 0, rowIndex: 0 };
+      }
+      // Otherwise, move caret to the previous line, either at the same offset
+      // as previously, or to the end of the line if it doesn't reach the offset
+      return {
+        offset: Math.min(offset, document[rowIndex - 1].length),
+        rowIndex: rowIndex - 1,
+      };
+    // Right arrow key
+    case 39:
+      // If the caret is at the end of the document, keep it as it is
+      if (
+        offset === document[rowIndex].length &&
+        rowIndex === document.length - 1
+      ) {
+        return { offset, rowIndex };
+      }
+      // If the caret is at the end of a line, move caret to the next line
+      if (offset === document[rowIndex].length) {
+        return { offset: 0, rowIndex: rowIndex + 1 };
+      }
+      return { offset: offset + 1, rowIndex };
+    // Down arrow key
+    case 40:
+      // If the caret is at the bottom of the document, keep it as it is.
+      if (rowIndex === document.length - 1) {
+        return { offset, rowIndex };
+      }
+      // Otherwise, move caret to the next line at the same offset. If the next
+      // line is shorter than the offset, move the caret to the end of the next
+      // line.
+      return {
+        offset: Math.min(offset, document[rowIndex - 1].length),
+        rowIndex: rowIndex + 1,
+      };
+    default:
+      return { offset, rowIndex };
   }
 };
 

--- a/client/src/components/Home/components/utilities.js
+++ b/client/src/components/Home/components/utilities.js
@@ -56,11 +56,7 @@ export const updateDocumentData = (
   }
 };
 
-export const updateCaretAtInput = (
-  document,
-  { offset, rowIndex },
-  { keyCode },
-) => {
+export const updateCaret = (document, { offset, rowIndex }, { keyCode }) => {
   switch (keyCode) {
     // Enter
     case 13:
@@ -84,18 +80,8 @@ export const updateCaretAtInput = (
     // Tab
     case 9:
       return { offset: offset + 2, rowIndex };
-    default:
-      return { offset: offset + 1, rowIndex };
-  }
-};
-
-export const updateCaretAtSpecialKey = (
-  document,
-  { offset, rowIndex },
-  { keyCode },
-) => {
-  switch (keyCode) {
-    // Left arrow key
+    // Arrow keys:
+    // Left
     case 37:
       // If the caret is at the beginning of the document, keep it as it is
       if (offset === 0 && rowIndex === 0) {
@@ -109,7 +95,7 @@ export const updateCaretAtSpecialKey = (
         };
       }
       return { offset: offset - 1, rowIndex };
-    // Up arrow key
+    // Up
     case 38:
       // If the caret is at the top of the document, keep it as it is
       if (rowIndex === 0) {
@@ -121,7 +107,7 @@ export const updateCaretAtSpecialKey = (
         offset: Math.min(offset, document[rowIndex - 1].length),
         rowIndex: rowIndex - 1,
       };
-    // Right arrow key
+    // Right
     case 39:
       // If the caret is at the end of the document, keep it as it is
       if (
@@ -135,7 +121,7 @@ export const updateCaretAtSpecialKey = (
         return { offset: 0, rowIndex: rowIndex + 1 };
       }
       return { offset: offset + 1, rowIndex };
-    // Down arrow key
+    // Down
     case 40:
       // If the caret is at the bottom of the document, keep it as it is.
       if (rowIndex === document.length - 1) {
@@ -145,11 +131,11 @@ export const updateCaretAtSpecialKey = (
       // line is shorter than the offset, move the caret to the end of the next
       // line.
       return {
-        offset: Math.min(offset, document[rowIndex - 1].length),
+        offset: Math.min(offset, document[rowIndex + 1].length),
         rowIndex: rowIndex + 1,
       };
     default:
-      return { offset, rowIndex };
+      return { offset: offset + 1, rowIndex };
   }
 };
 
@@ -171,6 +157,13 @@ export const setValueToStorage = (value) => {
   }
 };
 
+export const caretMovementKeys = {
+  37: 'left arrow',
+  38: 'up arrow',
+  39: 'right arrow',
+  40: 'down arrow',
+};
+
 export const listOfSpecialKeys = {
   91: 'command',
   18: 'option',
@@ -187,10 +180,6 @@ export const listOfSpecialKeys = {
   119: 'f8',
   120: 'f9',
   121: 'f10',
-  37: 'left arrow',
-  38: 'up arrow',
-  39: 'right arrow',
-  40: 'down arrow',
 };
 
 // export const isInListOfUnusedKeys = (values) => {


### PR DESCRIPTION
This commit will separate the function 'updateCaret' into two:
'updateCaretAtInput' (handles the movement of the caret when data is
entered/deleted) and 'updateCaretAtSpecialKey' (handles the movement
of the caret when a key is pressed).

The added function 'updateCaretAtSpecialKey' will handle the movement
of the caret by the arrow keys (left, up, right, and down).

Close issue #52.